### PR TITLE
Serialized variables

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,6 +4,29 @@
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
+        {
+            "name": "(gdb) Attach",
+            "type": "cppdbg",
+            "request": "attach",
+            "program": "${workspaceFolder}/videogame.exe",
+            "processId": "${command:pickProcess}",
+            "MIMode": "gdb",
+            "miDebuggerPath": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                },
+                {
+                    "description":  "Set Disassembly Flavor to Intel",
+                    "text": "-gdb-set disassembly-flavor intel",
+                    "ignoreFailures": true
+                }
+            ]
+        },
+
+
         
         {
             "name": "(gdb) Launch",
@@ -18,6 +41,7 @@
             "externalConsole": true,
             "MIMode": "gdb",
             "miDebuggerPath": "gdb",
+            "avoidWindowsConsoleRedirection": true,
             "setupCommands": [
                 {
                     "description": "Enable pretty-printing for gdb",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -67,6 +67,7 @@
         "set": "cpp",
         "regex": "cpp",
         "cinttypes": "cpp",
-        "variant": "cpp"
+        "variant": "cpp",
+        "any": "cpp"
     }
 }

--- a/data/screen/screen.yaml
+++ b/data/screen/screen.yaml
@@ -44,21 +44,27 @@ Defaults:
 
   Rates:
     DefaultTxtRate: &defaultText 17
-    DefaultCmdRate: &defaultCmd 100
+    DefaultCmdRate: &defaultCmd 17
 
-# the screens
-Screens:
-  Title:
-    Palette:
-      - *defaultBlack
+  Palettes:
+    CharacterCreationAndTitle: &titlePalette
+      - *defaultBlack 
       - 
         Number: 1
         Direct: No
         Base: [128.0, 128.0, 128.0, 0]
         Params: [8, 10, 11, 9]
         Function: 'WAVEFORM'
-      - *defaultGreen
-      - *defaultYellow
+      - 
+        Number: 2
+        Direct: Yes
+        Base: [192.0, 255, 254, 0]
+      - 
+        Number: 3
+        Direct: No
+        Base: [128.0, 128.0, 128.0, 0]
+        Params: [8, 10, 11, 12]
+        Function: 'WAVEFORM'
       - *defaultBlue
       - *defaultMagenta
       - *defaultCyan
@@ -70,7 +76,7 @@ Screens:
       -
         Number: 9
         Direct: Yes
-        Base: [1.0, 1, 1, 1]
+        Base: [0.0333, 0.02, 0.0147, 1]
       -
         Number: 10
         Direct: Yes
@@ -79,11 +85,20 @@ Screens:
         Number: 11
         Direct: Yes
         Base: *colorBlack
+      - 
+        Number: 12
+        Direct: Yes
+        Base: [0.1, 0.1, 0.1, 0.1]
+
+# the screens
+Screens:
+  Title:
+    Palette: *titlePalette
     Lines:
       - 
         Id: Title
-        TextRate: 17
-        CommandRate: 100
+        TextRate: *defaultText
+        CommandRate: *defaultCmd
         Centered: true
         Wrapped: Yes
         Bold: No
@@ -104,16 +119,16 @@ Screens:
                                # palette.
         Background: 0x00000000
       - Id: StartMessage
-        TextRate: 17           # How many milliseconds Videogame waits between 
-                               # Sending each glyph (what you see as the 
-                               # character) to the terminal. Lower numbers are
-                               # Faster. For reference, 16.66667 is 60 FPS (or
-                               # close enough to it).
-                               # 
-                               # Videogame cannot wait in fractions of
-                               # milliseconds.
-        CommandRate: 100       # Like text rate, but it adjusts the rate of 
-                               # Palette adjustments
+        TextRate: *defaultText   # How many milliseconds Videogame waits between 
+                                 # Sending each glyph (what you see as the 
+                                 # character) to the terminal. Lower numbers are
+                                 # Faster. For reference, 16.66667 is 60 FPS (or
+                                 # close enough to it).
+                                 # 
+                                 # Videogame cannot wait in fractions of
+                                 # milliseconds.
+        CommandRate: *defaultCmd # Like text rate, but it adjusts the rate of 
+                                 # Palette adjustments
         Centered: Yes
         Wrapped: Yes
         Bold: Yes
@@ -137,41 +152,12 @@ Screens:
       - IntroPart1
 # Begin the introduction things.
   IntroPart1:
-    Palette:
-      - *defaultBlack
-      - 
-        Number: 1
-        Direct: No
-        Base: [128.0, 128.0, 128.0, 0]
-        Params: [8, 10, 11, 9]
-        Function: 'WAVEFORM'
-      - *defaultGreen
-      - *defaultYellow
-      - *defaultBlue
-      - *defaultMagenta
-      - *defaultCyan
-      - *defaultWhite
-      -
-        Number: 8
-        Direct: Yes
-        Base: [128.0, 128, 128, 128]
-      -
-        Number: 9
-        Direct: Yes
-        Base: [1.0, 1, 1, 1]
-      -
-        Number: 10
-        Direct: Yes
-        Base: *colorBlack
-      - 
-        Number: 11
-        Direct: Yes
-        Base: *colorBlack
+    Palette: *titlePalette
     Lines:
       - 
         Id: Introduction0
-        TextRate: 17
-        CommandRate: 100
+        TextRate: *defaultText
+        CommandRate: *defaultCmd
         Centered: no
         Wrapped: yes
         Bold: no
@@ -190,8 +176,8 @@ Screens:
         Background: 0x00000000
       - 
         Id: Introduction1
-        TextRate: 17
-        CommandRate: 100
+        TextRate: *defaultText
+        CommandRate: *defaultCmd
         Centered: no
         Wrapped: yes
         Bold: no
@@ -210,8 +196,8 @@ Screens:
         Background: 0x00000000
       - 
         Id: Introduction2
-        TextRate: 17
-        CommandRate: 100
+        TextRate: *defaultText
+        CommandRate: *defaultCmd
         Centered: no
         Wrapped: yes
         Bold: no
@@ -230,8 +216,8 @@ Screens:
         Background: 0x00000000
       -
         Id: ContinueMessage
-        TextRate: 17
-        CommandRate: 100
+        TextRate: *defaultText
+        CommandRate: *defaultCmd
         Centered: no
         Wrapped: yes
         Bold: no
@@ -246,7 +232,7 @@ Screens:
         Font: 0
         Fraktur: no
         DoubleUnderline: no
-        Foreground: 0x00000001
+        Foreground: 0x00000003
         Background: 0x00000000
     Input:
       Expect:
@@ -255,41 +241,12 @@ Screens:
       - CharacterCreationPart1
 
   IntroductionPart2:
-    Palette:
-      - *defaultBlack
-      - 
-        Number: 1
-        Direct: No
-        Base: [128.0, 128.0, 128.0, 0]
-        Params: [8, 10, 11, 9]
-        Function: 'WAVEFORM'
-      - *defaultGreen
-      - *defaultYellow
-      - *defaultBlue
-      - *defaultMagenta
-      - *defaultCyan
-      - *defaultWhite
-      -
-        Number: 8
-        Direct: Yes
-        Base: [128.0, 128, 128, 128]
-      -
-        Number: 9
-        Direct: Yes
-        Base: [1.0, 1, 1, 1]
-      -
-        Number: 10
-        Direct: Yes
-        Base: *colorBlack
-      - 
-        Number: 11
-        Direct: Yes
-        Base: *colorBlack
+    Palette: *titlePalette
     Lines:
       - 
         Id: Introduction3
-        TextRate: 17
-        CommandRate: 100
+        TextRate: *defaultText
+        CommandRate: *defaultCmd
         Centered: no
         Wrapped: yes
         Bold: no
@@ -308,8 +265,8 @@ Screens:
         Background: 0x00000000
       - 
         Id: Introduction4
-        TextRate: 17
-        CommandRate: 100
+        TextRate: *defaultText
+        CommandRate: *defaultCmd
         Centered: no
         Wrapped: yes
         Bold: no
@@ -328,8 +285,8 @@ Screens:
         Background: 0x00000000
       - 
         Id: Introduction5
-        TextRate: 17
-        CommandRate: 100
+        TextRate: *defaultText
+        CommandRate: *defaultCmd
         Centered: no
         Wrapped: yes
         Bold: no
@@ -348,8 +305,8 @@ Screens:
         Background: 0x00000000
       - 
         Id: Introduction6
-        TextRate: 17
-        CommandRate: 100
+        TextRate: *defaultText
+        CommandRate: *defaultCmd
         Centered: no
         Wrapped: yes
         Bold: no
@@ -370,23 +327,12 @@ Screens:
       Expect:
         Mode: NONE
   Exit:
-    Palette:
-      - *defaultBlack
-      - *defaultRed
-      - 
-        Number: 2
-        Direct: Yes
-        Base: [192.0, 255, 248, 0]
-      - *defaultYellow
-      - *defaultBlue
-      - *defaultMagenta
-      - *defaultCyan
-      - *defaultWhite
+    Palette: *titlePalette
     Lines:
       - 
         Id: ExitMessage
-        TextRate: 17
-        CommandRate: 100
+        TextRate: *defaultText
+        CommandRate: *defaultCmd
         Centered: no
         Wrapped: yes
         Bold: no
@@ -409,41 +355,12 @@ Screens:
 # Begin the character creation things
 
   CharacterCreationPart1:
-    Palette:
-      - *defaultBlack
-      - 
-        Number: 1
-        Direct: No
-        Base: [128.0, 128.0, 128.0, 0]
-        Params: [8, 10, 11, 9]
-        Function: 'WAVEFORM'
-      - *defaultGreen
-      - *defaultYellow
-      - *defaultBlue
-      - *defaultMagenta
-      - *defaultCyan
-      - *defaultWhite
-      -
-        Number: 8
-        Direct: Yes
-        Base: [128.0, 128, 128, 128]
-      -
-        Number: 9
-        Direct: Yes
-        Base: [1.0, 1, 1, 1]
-      -
-        Number: 10
-        Direct: Yes
-        Base: *colorBlack
-      - 
-        Number: 11
-        Direct: Yes
-        Base: *colorBlack
+    Palette: *titlePalette
     Lines:
       - 
         Id: CharacterCreation0
-        TextRate: 17
-        CommandRate: 100
+        TextRate: *defaultText
+        CommandRate: *defaultCmd
         Centered: no
         Wrapped: yes
         Bold: no
@@ -465,8 +382,8 @@ Screens:
         Mode: FULL_NAME
       Remind:
         Id: NameEntryReminder
-        TextRate: 17
-        CommandRate: 100
+        TextRate: *defaultText
+        CommandRate: *defaultCmd
         Centered: no
         Wrapped: yes
         Bold: no
@@ -487,41 +404,12 @@ Screens:
       - CharacterCreationPart2
 
   CharacterCreationPart2:
-    Palette:
-      - *defaultBlack
-      - 
-        Number: 1
-        Direct: No
-        Base: [128.0, 128.0, 128.0, 0]
-        Params: [8, 10, 11, 9]
-        Function: 'WAVEFORM'
-      - *defaultGreen
-      - *defaultYellow
-      - *defaultBlue
-      - *defaultMagenta
-      - *defaultCyan
-      - *defaultWhite
-      -
-        Number: 8
-        Direct: Yes
-        Base: [128.0, 128, 128, 128]
-      -
-        Number: 9
-        Direct: Yes
-        Base: [1.0, 1, 1, 1]
-      -
-        Number: 10
-        Direct: Yes
-        Base: *colorBlack
-      - 
-        Number: 11
-        Direct: Yes
-        Base: *colorBlack
+    Palette: *titlePalette
     Lines:
       - 
         Id: CharacterCreation1
-        TextRate: 17
-        CommandRate: 100
+        TextRate: *defaultText
+        CommandRate: *defaultCmd
         Centered: no
         Wrapped: yes
         Bold: no

--- a/data/screen/screen.yaml
+++ b/data/screen/screen.yaml
@@ -402,7 +402,7 @@ Screens:
         Mode: NONE
 # Begin the character creation things
 
-    CharacterCreationPart1:
+  CharacterCreationPart1:
     Palette:
       - *defaultBlack
       - 
@@ -456,7 +456,7 @@ Screens:
         Background: 0x00000000
     Input:
       Expect:
-        Mode: NONE # TODO: replace with input that gets one or two strings.
+        Mode: FULL_NAME
       Remind:
         Id: NameEntryReminder
         TextRate: 17

--- a/data/screen/screen.yaml
+++ b/data/screen/screen.yaml
@@ -247,6 +247,8 @@ Screens:
     Input:
       Expect:
         Mode: NONE
+    Next:
+      - CharacterCreationPart1
 
   IntroductionPart2:
     Palette:
@@ -476,7 +478,7 @@ Screens:
         Fraktur: no
         DoubleUnderline: no
         Foreground: 0x00000007
-        Backgroudn: 0x00000000
+        Background: 0x00000000
     Next:
       - CharacterCreationPart2
 

--- a/data/screen/screen.yaml
+++ b/data/screen/screen.yaml
@@ -41,7 +41,11 @@ Defaults:
       Number: 7
       Direct: Yes
       Base: &colorWhite [200.0, 200, 200, 0]
-      
+
+  Rates:
+    DefaultTxtRate: &defaultText 17
+    DefaultCmdRate: &defaultCmd 100
+
 # the screens
 Screens:
   Title:

--- a/source/init/main.c++
+++ b/source/init/main.c++
@@ -119,10 +119,26 @@ int main ( int const argc, char const *const *const argv )
         }
     };
 
+    // first and last name as grabbed from the name input.
+    defines::IString firstName;
+    defines::IString lastName;
+
     for ( ux::console::Screen screen = getScreen ( "Title" );;
           screen                     = chooseNext ( screen ) )
     {
         con << screen.output ( *strings, locale, translit );
+        // check if the screen is the part which asks for the first name and
+        // last name of the hypothetical character.
+        if ( screen == getScreen ( "CharacterCreationPart1" ) )
+        {
+            // get the first and last name.
+            auto temp = std::get< std::array< defines::IString, 2 > > (
+                    screen.inputPrompt.result );
+            firstName = temp [ 0 ];
+            lastName  = temp [ 1 ];
+        }
+
+        con << "Read in the name \"" << firstName << ", " << lastName << "\"\n";
     }
     // set up some (hopefully) flashing text
     // con << setDirectColor ( 8, 1, 1, 1 );

--- a/source/init/main.c++
+++ b/source/init/main.c++
@@ -132,27 +132,36 @@ int main ( int const argc, char const *const *const argv )
     for ( ux::console::Screen screen = getScreen ( "Title" );;
           screen                     = chooseNext ( screen ) )
     {
+        std::cin.clear ( );
         con << screen.output ( *strings, locale, translit );
         // check if the screen is the part which asks for the first name and
         // last name of the hypothetical character.
         if ( currentScreenName == "CharacterCreationPart1" )
         {
-            if ( std::any_cast< std::vector< defines::IString > > (
-                         &screen.inputPrompt.result ) )
+            while ( !screen.inputPrompt.inputReady ) { }
+            defines::ChrString *temp = nullptr;
+            try
             {
-                firstName = std::any_cast< std::vector< defines::IString > > (
-                        screen.inputPrompt.result ) [ 0 ];
-                lastName = std::any_cast< std::vector< defines::IString > > (
-                        screen.inputPrompt.result ) [ 1 ];
+                temp = std::any_cast< defines::ChrString * > (
+                        screen.inputPrompt.result );
+            } catch ( std::bad_any_cast &bac )
+            {
+                io::base::osyncstream { std::cout }
+                        << "Failed to read in the name. Despite what the "
+                           "result "
+                           "types say, we see the input as a "
+                        << screen.inputPrompt.result.type ( ).name ( ) << "\n";
+            }
 
-                con << "Name read is " << firstName << " " << lastName << "\n";
-            } else
+            if ( temp )
             {
-                con << "For some reason, the stored input is of type "
-                    << screen.inputPrompt.result.type ( ).name ( ) << "\n";
+                con << "Read in the data " << temp [ 0 ] << " and "
+                    << temp [ 1 ] << "\n";
             }
         }
     }
+
+    std::cin.get ( );
     // set up some (hopefully) flashing text
     // con << setDirectColor ( 8, 1, 1, 1 );
     // con << setDirectColor ( 9, 0x80, 0x80, 0x80, 0x80 );

--- a/source/io/console/console.c++
+++ b/source/io/console/console.c++
@@ -158,6 +158,9 @@ struct io::console::Console::impl_s
 #endif
         std::cout << "\u001b[3J\u001b[2J\u001b[0m\u001b[H";
         std::cout.flush ( );
+        // untie std::cin and std::cout
+        std::cin.tie ( nullptr );
+        std::cout.tie ( nullptr );
         readySignal.store ( true );
         sizeUpdater = std::jthread ( [ & ] ( ) { sizeUpdateFunction ( ); } );
         sizeUpdater.detach ( );

--- a/source/ux/console/screen.c++
+++ b/source/ux/console/screen.c++
@@ -191,9 +191,6 @@ ConsoleManipulator
         bool matches = false;
         do {
             std::cin.clear ( );
-            defines::ChrString input = "";
-            std::getline ( std::cin, input );
-
             // check against input
             // get the input
             matches =
@@ -210,32 +207,18 @@ bool inputModeNone ( InputResult & ) { return true; }
 
 bool inputModeFullName ( InputResult &result )
 {
-    defines::ChrStringStream line;
-
-    auto getLine = [ & ] ( ) {
-        defines::ChrString temp = "";
-        std::getline ( std::cin, temp );
-        line = defines::ChrStringStream ( temp );
-    };
-
-    getLine ( );
     defines::ChrString name [ 2 ] = { "", "" };
-    for ( std::size_t i = 0; i < 2; i++ )
+    std::cin >> name [ 0 ] >> name [ 1 ];
     {
-        if ( line )
-        {
-            line >> name [ i ];
-        } else
-        {
-            return false;
-        }
+        io::base::osyncstream { std::cout } << name [ 0 ] << ", " << name [ 1 ]
+                                            << "\n";
     }
-    result = std::array< defines::IString, 2 > {
-            io::console::manip::convert< defines::IChar, defines::ChrChar > (
-                    name [ 0 ] ),
-            io::console::manip::convert< defines::IChar, defines::ChrChar > (
-                    name [ 1 ] ),
-    };
+    if ( name [ 0 ].empty ( ) || name [ 1 ].empty ( ) )
+    {
+        return false;
+    }
+    result.emplace< std::vector< defines::ChrString > > (
+            { name [ 0 ], name [ 1 ] } );
     return true;
 }
 
@@ -244,6 +227,7 @@ InputModeGetter parseInputMode ( InputModes const &mode )
     switch ( mode )
     {
         case InputModes::NONE: return &inputModeNone;
+        case InputModes::FULL_NAME: return &inputModeFullName;
         default: return &inputModeNone;
     }
 }

--- a/source/ux/console/screen.c++
+++ b/source/ux/console/screen.c++
@@ -195,15 +195,23 @@ ConsoleManipulator
             // get the input
             matches =
                     parseInputMode ( inputPrompt.mode ) ( inputPrompt.result );
+            io::base::osyncstream { std::cout }
+                    << "Result type as currently read is "
+                    << inputPrompt.result.type ( ).name ( ) << "\n";
 
         } while ( !matches );
-
+        inputPrompt.inputReady = true;
         return console;
     };
 }
 
 // the input modes.
-bool inputModeNone ( InputResult & ) { return true; }
+bool inputModeNone ( InputResult & )
+{
+    defines::ChrString temp = "";
+    std::getline ( std::cin, temp );
+    return true;
+}
 
 bool inputModeFullName ( InputResult &result )
 {
@@ -217,8 +225,11 @@ bool inputModeFullName ( InputResult &result )
     {
         return false;
     }
-    result.emplace< std::vector< defines::ChrString > > (
-            { name [ 0 ], name [ 1 ] } );
+    result = std::make_any< defines::ChrString * > (
+            new defines::ChrString [ 2 ] { name [ 0 ], name [ 1 ] } );
+    io::base::osyncstream { std::cout } << "Result type as stored is "
+                                        << result.type ( ).name ( ) << "\n";
+    std::cin.clear ( );
     return true;
 }
 

--- a/source/ux/console/screen.c++
+++ b/source/ux/console/screen.c++
@@ -168,7 +168,7 @@ ConsoleManipulator
             assert ( !string.empty ( ) );
             // wait until we have finished outputting the line.
             console << doWaitForText;
-            if (!string.ends_with("\n"))
+            if ( !string.ends_with ( "\n" ) )
             {
                 string += "\n";
             }
@@ -207,6 +207,37 @@ ConsoleManipulator
 
 // the input modes.
 bool inputModeNone ( InputResult & ) { return true; }
+
+bool inputModeFullName ( InputResult &result )
+{
+    defines::ChrStringStream line;
+
+    auto getLine = [ & ] ( ) {
+        defines::ChrString temp = "";
+        std::getline ( std::cin, temp );
+        line = defines::ChrStringStream ( temp );
+    };
+
+    getLine ( );
+    defines::ChrString name [ 2 ] = { "", "" };
+    for ( std::size_t i = 0; i < 2; i++ )
+    {
+        if ( line )
+        {
+            line >> name [ i ];
+        } else
+        {
+            return false;
+        }
+    }
+    result = std::array< defines::IString, 2 > {
+            io::console::manip::convert< defines::IChar, defines::ChrChar > (
+                    name [ 0 ] ),
+            io::console::manip::convert< defines::IChar, defines::ChrChar > (
+                    name [ 1 ] ),
+    };
+    return true;
+}
 
 InputModeGetter parseInputMode ( InputModes const &mode )
 {

--- a/source/ux/console/screen.h++
+++ b/source/ux/console/screen.h++
@@ -105,8 +105,8 @@ namespace ux::console
     struct Input
     {
         InputModes mode            = InputModes::_MAX;
-        bool       inputReady      = false;
-        InputResult mutable result = { };
+        bool mutable inputReady    = false;
+        InputResult mutable result = 0;
 
         bool const operator== ( Input const &in ) const noexcept
         {

--- a/source/ux/console/screen.h++
+++ b/source/ux/console/screen.h++
@@ -25,6 +25,7 @@
 
 #include <io/base/syncstream.h++>
 
+#include <array>
 #include <functional>
 #include <iostream>
 #include <list>
@@ -94,11 +95,13 @@ namespace ux::console
 
     enum class InputModes
     {
-        NONE, // wait for the user to press enter.
+        NONE,      // wait for the user to press enter.
+        FULL_NAME, // get two strings delimited by a space.
         _MAX,
     };
 
-    using InputResult = std::variant< void * >;
+    using InputResult =
+            std::variant< void *, std::array< defines::IString, 2 > >;
 
     struct Input
     {
@@ -129,9 +132,9 @@ namespace ux::console
         std::list< serialization::ExternalID > nextScreen;
 
         io::console::ConsoleManipulator
-                   output ( serialization::ExternalizedStrings const  &strings,
-                            defines::IString const                    &locale,
-                            serialization::TransliterationLevel const &level );
-        bool operator== ( Screen const &screen ) const noexcept = default;
+                output ( serialization::ExternalizedStrings const  &strings,
+                         defines::IString const                    &locale,
+                         serialization::TransliterationLevel const &level );
+        bool    operator== ( Screen const &screen ) const noexcept = default;
     };
 } // namespace ux::console

--- a/source/ux/console/screen.h++
+++ b/source/ux/console/screen.h++
@@ -25,12 +25,12 @@
 
 #include <io/base/syncstream.h++>
 
+#include <any>
 #include <array>
 #include <functional>
 #include <iostream>
 #include <list>
 #include <map>
-#include <variant>
 
 namespace ux::console
 {
@@ -100,8 +100,7 @@ namespace ux::console
         _MAX,
     };
 
-    using InputResult =
-            std::variant< void *, std::array< defines::IString, 2 > >;
+    using InputResult = std::any;
 
     struct Input
     {

--- a/source/ux/serialization/screens.c++
+++ b/source/ux/serialization/screens.c++
@@ -97,11 +97,6 @@ void ux::serialization::ExternalizedScreens::_parse (
 
         parsed.inputPrompt.mode = defines::fromString< InputModes > (
                 input [ "Expect" ][ "Mode" ].Scalar ( ) );
-        std::cout << input [ "Expect" ][ "Mode" ].Scalar ( ) << "\n";
-        std::cout << defines::rtToString< InputModes > (
-                parsed.inputPrompt.mode )
-                  << "\n";
-        std::cin.get ( );
         parsed.wrongAnswer = input [ "Remind" ]
                                    ? parseLine ( input [ "Remind" ] )
                                    : Line { "EmptyString" };

--- a/source/ux/serialization/screens.c++
+++ b/source/ux/serialization/screens.c++
@@ -96,7 +96,12 @@ void ux::serialization::ExternalizedScreens::_parse (
         }
 
         parsed.inputPrompt.mode = defines::fromString< InputModes > (
-                input [ "Expect" ][ "Mode" ].as< defines::ChrString > ( ) );
+                input [ "Expect" ][ "Mode" ].Scalar ( ) );
+        std::cout << input [ "Expect" ][ "Mode" ].Scalar ( ) << "\n";
+        std::cout << defines::rtToString< InputModes > (
+                parsed.inputPrompt.mode )
+                  << "\n";
+        std::cin.get ( );
         parsed.wrongAnswer = input [ "Remind" ]
                                    ? parseLine ( input [ "Remind" ] )
                                    : Line { "EmptyString" };


### PR DESCRIPTION
The code in this branch, when ready, will allow the engine to programmatically grab variables defined in the data-files and use them within other text. For example,
```YAML
Player:
  Name:
    - Type: Variable
      Key: CharacterCreation1.Input.0
      Reference: PlayerFirstName
    - Type: Variable
      Key: CharacterCreation2.Input.1
      Reference: PlayerLastName
```
Might refer to the input from:
```YAML
Screens:
  # -- snip --
  CharacterCreation1:
    Palette: *titlePalette
    Lines:
      -
        Id: CharacterCreation0
        TextRate: *defaultText
        CommandRate: *defaultCmd
        # -- snip
    Input:
      Expect:
       Mode: FULL_NAME
      Remind:
       Id: NameEntryReminder
 # -- snip --
---
```
And allow text to simply refer to PlayerFirstName and PlayerLastName to get the first and last name of the player character. Also, such a system would allow an engine to serialize these variables in that same key-value format:
```YAML
Variables:
  PlayerFirstName: 'Your'
  PlayerLastName: 'Name'
```